### PR TITLE
Update lager import path to use code.cloudfoundry.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: go
 matrix:
   include:
-    - go: '1.4'
+    - go: '1.6'
 before_script:
   - go get golang.org/x/tools/cmd/cover
-  - go get golang.org/x/tools/cmd/vet
   - go get github.com/golang/lint/golint
   - go get github.com/modocache/gover
   - go get github.com/mattn/goveralls

--- a/glager.go
+++ b/glager.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/types"
-	"github.com/pivotal-golang/lager"
 )
 
 type logEntry lager.LogFormat

--- a/glager_test.go
+++ b/glager_test.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"testing"
 
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/types"
-	"github.com/pivotal-golang/lager"
-	"github.com/pivotal-golang/lager/lagertest"
 	. "github.com/st3v/glager"
 )
 


### PR DESCRIPTION
Hey there,

We updated the lager import path to use the `code.cloudfoundry.org`

Signed-off-by: Claudia Beresford cberesford@pivotal.io
